### PR TITLE
feat(treesitter): make import and generate the treesitter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1694476120,
-        "narHash": "sha256-4bBsnmhCWb9Z4V4ZUIcsrx9iyo4grIGTbY3q2HnG1X8=",
+        "lastModified": 1694530540,
+        "narHash": "sha256-vDK+iO1nZjKE3xzAfeDBr2zKa3nBGvXrb4VfFxRFpLk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "aab06edc63c3dfbd99e0c803c6834bf771318c42",
+        "rev": "1f551e068f728ff38bd7fdcfa3a6daf362bab9da",
         "type": "github"
       },
       "original": {
@@ -206,11 +206,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694477020,
-        "narHash": "sha256-NncWOD+5bW4wCxO22K2npYNqOYvOSpye837gMB/UjpI=",
+        "lastModified": 1694563461,
+        "narHash": "sha256-ILJ9RnF0h3Lt7CZwxggfUB+enadTt24JNDyDHSwpvz0=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "d68c4f9302b2a7fb5c9dedc3cfa3ac9bd33fb0c6",
+        "rev": "e66f37fcd1e013c7925b26aed7cf019294edcb27",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1694343207,
-        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
+        "lastModified": 1694593561,
+        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "rev": "1697b7d480449b01111e352021f46e5879e47643",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,28 @@
         "type": "github"
       }
     },
+    "nvimTreesitter": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1694589169,
+        "narHash": "sha256-U/27eclZ7V1ax03lV3qtGCSRcoT/1kv9BW3FtKjno8k=",
+        "owner": "nvim-treesitter",
+        "repo": "nvim-treesitter",
+        "rev": "9ab4e9cc8989e3811b14897cd0eb21ae35e5541e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-treesitter",
+        "repo": "nvim-treesitter",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "nvimTreesitter": "nvimTreesitter"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,22 +12,32 @@
     };
     # Utils for the mapping the system variable etc.
     flake-utils.url = "github:numtide/flake-utils";
+    # nvim-treesitter to have access to the lock file
+    nvimTreesitter = {
+      url = "github:nvim-treesitter/nvim-treesitter";
+      flake = false;
+    };
   };
   outputs =
     { self
     , nixpkgs
     , flake-utils
     , neovim-nightly-overlay
+    , nvimTreesitter
     }@inputs: {
       nixosModules = import ./nix/nixosModules.nix inputs;
       homeManagerModules = import ./nix/homeManagerModules.nix inputs;
     } // flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs { inherit system; };
+      nvim-treesitter = callPackage ./nix/treesitter.nix { inherit nvimTreesitter; };
       inherit (pkgs) callPackage;
     in
     {
       checks.check = callPackage ./nix/check.nix { };
       devShells.default = callPackage ./nix/shell.nix { };
-    });
+      packages.nvim-treesitter = nvim-treesitter;
+    }) // {
+      overlays.nvim-treesitter = import ./nix/treesitterOverlay.nix nvimTreesitter;
+    };
 }

--- a/lua/user-config/plugins.lua
+++ b/lua/user-config/plugins.lua
@@ -26,20 +26,25 @@ function M.setup()
   end
 
   --- Include nix runtime paths
-  local tree_sitter = {}
   local nix_rtp = {}
+  local remove = {}
   --- Load all the tree-sitter parsers
-  for s in vim.o.rtp:gmatch('([^,]+vim%-pack%-dir),') do
-    local path = s .. '/pack/myNeovimPackages/start'
-
-    for dir in vim.fs.dir(path) do
-      if dir == 'nvim-treesitter' then
-        --- Set nvim-treesitter path
-        vim.g.tree_sitter_path = path .. '/' .. dir
-      else
-        -- Make parsers available in the runtime path
-        table.insert(nix_rtp, path .. '/' .. dir)
+  for _, rtp in pairs(vim.opt.rtp:get()) do
+    if rtp:match('vim%-pack%-dir') then
+      --  Nix path
+      local path = rtp .. '/pack/myNeovimPackages/start'
+      for dir in vim.fs.dir(path) do
+        if dir == 'nvim-treesitter' then
+          --- Set nvim-treesitter path
+          vim.g.tree_sitter_path = path .. '/' .. dir
+        else
+          -- Make parsers available in the runtime path
+          table.insert(nix_rtp, path .. '/' .. dir)
+        end
       end
+    elseif rtp:match('lib/nvim') then
+      -- Remove bundled treesitter parsers
+      table.insert(remove, rtp)
     end
   end
 
@@ -58,6 +63,10 @@ function M.setup()
       },
     },
   })
+
+  for _, rtp in pairs(remove) do
+    vim.opt.rtp:remove(rtp)
+  end
 end
 
 return M

--- a/nix/treesitter.nix
+++ b/nix/treesitter.nix
@@ -1,0 +1,105 @@
+# Create the tree-sitter
+{ lib
+, stdenvNoCC
+, neovim
+, tree-sitter
+, vimPlugins
+, neovimUtils
+, nvimTreesitter
+}:
+let
+  nvim-treesitter = vimPlugins.nvim-treesitter.overrideAttrs {
+    src = nvimTreesitter;
+    version = "0.0.0+rev=" + nvimTreesitter.shortRev;
+  };
+  nvim = neovim.override {
+    configure.packages.all.start = [ nvim-treesitter ];
+  };
+  lock = stdenvNoCC.mkDerivation {
+    name = "nvim-treesitter-lock";
+    src = nvimTreesitter;
+    buildInputs = [ nvim ];
+    noBuild = true;
+    installPhase = ''
+      set -eEuo pipefail
+
+      mkdir -p $out
+
+      nvim --headless -i NONE \
+        "+lua io.write(vim.json.encode(require('nvim-treesitter.parsers').get_parser_configs()))" \
+        +quit! | tee "$out/config.json"
+
+      cp -v lockfile.json "$out/lockfile.json"
+    '';
+  };
+  generatedGrammars =
+    let
+      lockRev = lib.importJSON (lock + /lockfile.json);
+      config = lib.importJSON (lock + /config.json);
+    in
+    builtins.mapAttrs
+      (name: value:
+        let
+          rev = lockRev.${name}.revision;
+          shortRev = builtins.substring 0 7 rev;
+          hasLocation = builtins.hasAttr "location" value.install_info;
+          hasGenerate = builtins.hasAttr "requires_generate_from_grammar" value.install_info;
+          inherit (value.install_info) url;
+        in
+        tree-sitter.buildGrammar (
+          {
+            language = name;
+            version = "0.0.0+rev" + shortRev;
+            src = builtins.fetchGit {
+              inherit url rev;
+              allRefs = true;
+            };
+            meta.homepage = url;
+          } // lib.optionalAttrs hasLocation {
+            inherit (value.install_info) location;
+          } // lib.optionalAttrs hasGenerate {
+            generate = value.install_info.requires_generate_from_grammar;
+          }
+        ))
+      config;
+  generatedDerivations = lib.filterAttrs (_: lib.isDerivation) generatedGrammars;
+  # add aliases so grammars from `tree-sitter` are overwritten in `withPlugins`
+  # for example, for ocaml_interface, the following aliases will be added
+  #   ocaml-interface
+  #   tree-sitter-ocaml-interface
+  #   tree-sitter-ocaml_interface
+  builtGrammars = generatedGrammars // lib.concatMapAttrs
+    (k: v:
+      let
+        replaced = lib.replaceStrings [ "_" ] [ "-" ] k;
+      in
+      {
+        "tree-sitter-${k}" = v;
+      } // lib.optionalAttrs (k != replaced) {
+        ${replaced} = v;
+        "tree-sitter-${replaced}" = v;
+      })
+    generatedDerivations;
+  allGrammars = lib.attrValues generatedDerivations;
+in
+vimPlugins.nvim-treesitter.overrideAttrs (final: prev:
+let
+  # Usage:
+  # pkgs.vimPlugins.nvim-treesitter.withPlugins (p: [ p.c p.java ... ])
+  # or for all grammars:
+  # pkgs.vimPlugins.nvim-treesitter.withAllGrammars
+  withPlugins =
+    f: final.overrideAttrs {
+      passthru.dependencies = map neovimUtils.grammarToPlugin
+        (f (tree-sitter.builtGrammars // builtGrammars));
+    };
+  withAllGrammars = withPlugins (_: allGrammars);
+in
+{
+  src = nvimTreesitter;
+  version = "0.0.0+rev=" + nvimTreesitter.shortRev;
+  passthru = lib.recursiveUpdate prev.passthru {
+    nvim-treesitter-lock = lock;
+    inherit builtGrammars allGrammars withPlugins withAllGrammars;
+  };
+})

--- a/nix/treesitterOverlay.nix
+++ b/nix/treesitterOverlay.nix
@@ -1,0 +1,14 @@
+nvimTreesitter:
+final: prev:
+{
+  vimPlugins = prev.vimPlugins.extend (final': prev':
+    let
+      nvim-treesitter = prev.callPackage ./treesitter.nix {
+        vimPlugins = prev';
+        inherit nvimTreesitter;
+      };
+    in
+    {
+      inherit nvim-treesitter;
+    });
+}

--- a/spell/en.utf-8.add
+++ b/spell/en.utf-8.add
@@ -488,3 +488,4 @@ edgehog
 dropdown
 esc
 desc
+nvim


### PR DESCRIPTION
Make treesitter a flake input so that the parsers are easier to update with the lock file. Remove the integrated treesitter parsers from the RTP path so they don't conflict with the one in nvim-treesitter.