### PR TITLE
fix(update): don't commit-lock-file

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -32,8 +32,14 @@ fi
 
 is_git_clean
 
-nix flake update --commit-lock-file
-changed+=', flake.lock'
+nix flake update
+
+if ! git diff --quiet lazy-lock.json; then
+    git add flake.lock
+    git commit -m 'chore(nix): update flake.lock'
+
+    changed+=', flake.lock'
+fi
 
 is_git_clean
 


### PR DESCRIPTION
Since the generated lines would be too long for a git-commit